### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-performance-test.yml
+++ b/.github/workflows/manual-performance-test.yml
@@ -1,5 +1,8 @@
 name: Manual Trigger for Performance Test
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/dvsa/vol-app-performance-suite/security/code-scanning/1](https://github.com/dvsa/vol-app-performance-suite/security/code-scanning/1)

In general, fix this by adding an explicit `permissions:` block either at the workflow root (applies to all jobs) or on the specific job, granting only the minimum permissions actually needed. When unsure, a safe baseline for workflows that only need to read repository contents is `permissions: { contents: read }` at the root. Because this workflow only dispatches another workflow and passes inputs/vars, there’s no indication it needs to write to the repo or manage other resources directly, so a root-level `contents: read` is an appropriate minimal starting point.

Concretely, update `.github/workflows/manual-performance-test.yml` by inserting a `permissions:` section after the `name:` line and before `on:`. For example:

```yaml
name: Manual Trigger for Performance Test

permissions:
  contents: read

on:
  workflow_dispatch:
  ...
```

This change leaves the existing structure and behavior of the workflow intact, while explicitly constraining the `GITHUB_TOKEN` for this workflow to read-only repository contents, satisfying the CodeQL rule and documenting the intended permission level. No additional imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
